### PR TITLE
Theme function to output image tag + other things

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{php,js,css,scss}]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+node_modules

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This plugin does two main things:
 1. Provides a simple function `cloudinary_url()` to get a Cloudinary auto-upload URL for any image in your media library, with all the Cloudinary transformations, so you can **dynamically manipulate an image on the fly**.
 1. Attempts to automatically convert all image URLs on the front-end into a Cloudinary auto-upload URL, so you can **use Cloudinary as an image CDN**.
 
-## The magical function 🎩
+## Magical functions 🎩
 
 #### `cloudinary_url( $identifier, $args )`
 
@@ -120,4 +120,33 @@ $url_2 = cloudinary_url( 'https://www.yourwebsite.com/wp-content/uploads/2017/12
 
 <img src="<?php echo esc_url( $url_1 ); ?>" width="300" height="200" alt="">
 <img src="<?php echo esc_url( $url_2 ); ?>" width="100" height="100" alt="">
+```
+
+#### `cloudinary_image( $identifier, $args )`
+
+**Parameters**
+
+* **identifier** (integer/string)(required) : Either the ID of the attachment, or a full image URL.
+* **args** (array)(optional) : Arguments to manipulate the image and/or <img> tag.
+
+**Return Value**
+
+Returns an <img> tag:
+
+```html
+<img loading="lazy" src="...">
+```
+
+#### Examples:
+
+```php
+<?php
+echo cloudinary_image( 123, array(
+	'width'   => 300,
+	'crop'    => 'fill',
+	'atts'    => [
+		'alt'   => 'Image alt',
+		'class' => '...',
+ 	],
+) );
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "junaidbhura/auto-cloudinary",
+    "description": "Super simple Cloudinary auto-upload implementation for WordPress.",
+    "type": "wordpress-plugin",
+    "license": ["GPL-2.0-only"],
+    "require": {
+      "php": ">=5.6"
+    },
+    "require-dev": {
+      "10up/phpcs-composer": "dev-master"
+    },
+    "scripts": {
+      "lint": "phpcs auto-cloudinary.php inc",
+      "lint-fix": "phpcbf auto-cloudinary.php inc"
+    }
+  }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,379 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "02c4cf364cf39922747f6b18d538225a",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "10up/phpcs-composer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/10up/phpcs-composer.git",
+                "reference": "2fcd33205f7742c46fa09b28829321d847cc472d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/2fcd33205f7742c46fa09b28829321d847cc472d",
+                "reference": "2fcd33205f7742c46fa09b28829321d847cc472d",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "phpcompatibility/phpcompatibility-wp": "^2",
+                "squizlabs/php_codesniffer": "^3.4.0",
+                "wp-coding-standards/wpcs": "*"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ephraim Gregor",
+                    "email": "ephraim.gregor@10up.com"
+                }
+            ],
+            "time": "2020-07-15T03:05:06+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-06-25T14:57:39+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2019-11-04T15:17:54+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-08-10T04:50:15+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "10up/phpcs-composer": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.6"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -14,6 +14,47 @@ class Core {
 	public $_urls                = array();
 	private $_url_counter        = 0;
 
+	public $cloudinary_params = array(
+		'angle'                => 'a',
+		'aspect_ratio'         => 'ar',
+		'background'           => 'b',
+		'border'               => 'bo',
+		'crop'                 => 'c',
+		'color'                => 'co',
+		'dpr'                  => 'dpr',
+		'duration'             => 'du',
+		'effect'               => 'e',
+		'end_offset'           => 'eo',
+		'flags'                => 'fl',
+		'height'               => 'h',
+		'overlay'              => 'l',
+		'opacity'              => 'o',
+		'quality'              => 'q',
+		'radius'               => 'r',
+		'start_offset'         => 'so',
+		'named_transformation' => 't',
+		'underlay'             => 'u',
+		'video_codec'          => 'vc',
+		'width'                => 'w',
+		'x'                    => 'x',
+		'y'                    => 'y',
+		'zoom'                 => 'z',
+		'audio_codec'          => 'ac',
+		'audio_frequency'      => 'af',
+		'bit_rate'             => 'br',
+		'color_space'          => 'cs',
+		'default_image'        => 'd',
+		'delay'                => 'dl',
+		'density'              => 'dn',
+		'fetch_format'         => 'f',
+		'gravity'              => 'g',
+		'prefix'               => 'p',
+		'page'                 => 'pg',
+		'video_sampling'       => 'vs',
+		'progressive'          => 'fl_progressive',
+		'format'               => 'f',
+	);
+
 	/**
 	 * Get current instance.
 	 *
@@ -37,8 +78,7 @@ class Core {
 		$this->_default_hard_crop     = get_option( 'cloudinary_default_hard_crop' );
 		$this->_default_soft_crop     = get_option( 'cloudinary_default_soft_crop' );
 		$this->_options['urls']       = get_option( 'cloudinary_urls' );
-		$upload_dir                   = wp_upload_dir();
-		$this->_options['upload_url'] = apply_filters( 'cloudinary_upload_url', $upload_dir['baseurl'] );
+		$this->_options['upload_url'] = apply_filters( 'cloudinary_upload_url', WP_CONTENT_URL );
 
 		if ( ! empty( $this->_cloud_name ) && ! empty( $this->_auto_mapping_folder ) ) {
 			$this->_setup = true;
@@ -112,6 +152,14 @@ class Core {
 		if ( ! empty( $args['file_name'] ) ) {
 			$url .= '/images';
 		}
+		
+		$extension = null;
+
+		if ( ! empty( $args['transform']['format'] ) && 'auto' !== $args['transform']['format'] ) {
+			$extension = $args['transform']['format'];
+
+			unset( $args['transform']['format'] );
+		}
 
 		// Transformations.
 		if ( ! empty( $args['transform'] ) ) {
@@ -128,6 +176,10 @@ class Core {
 		if ( ! empty( $args['file_name'] ) ) {
 			$path_info = pathinfo( $url );
 			$url       = str_replace( $path_info['filename'], $path_info['filename'] . '/' . $args['file_name'], $url );
+		}
+
+		if ( ! empty( $extension ) ) {
+			$url = preg_replace( '#^(.*\.).*$#', '$1' . $extension, $url );
 		}
 
 		// All done, let's return it.
@@ -193,59 +245,19 @@ class Core {
 			return '';
 		}
 
-		$cloudinary_params = array(
-			'angle'                => 'a',
-			'aspect_ratio'         => 'ar',
-			'background'           => 'b',
-			'border'               => 'bo',
-			'crop'                 => 'c',
-			'color'                => 'co',
-			'dpr'                  => 'dpr',
-			'duration'             => 'du',
-			'effect'               => 'e',
-			'end_offset'           => 'eo',
-			'flags'                => 'fl',
-			'height'               => 'h',
-			'overlay'              => 'l',
-			'opacity'              => 'o',
-			'quality'              => 'q',
-			'radius'               => 'r',
-			'start_offset'         => 'so',
-			'named_transformation' => 't',
-			'underlay'             => 'u',
-			'video_codec'          => 'vc',
-			'width'                => 'w',
-			'x'                    => 'x',
-			'y'                    => 'y',
-			'zoom'                 => 'z',
-			'audio_codec'          => 'ac',
-			'audio_frequency'      => 'af',
-			'bit_rate'             => 'br',
-			'color_space'          => 'cs',
-			'default_image'        => 'd',
-			'delay'                => 'dl',
-			'density'              => 'dn',
-			'fetch_format'         => 'f',
-			'gravity'              => 'g',
-			'prefix'               => 'p',
-			'page'                 => 'pg',
-			'video_sampling'       => 'vs',
-			'progressive'          => 'fl_progressive',
-		);
-
 		$slug = array();
 		foreach ( $args as $key => $value ) {
-			if ( array_key_exists( $key, $cloudinary_params ) && $this->valid_value( $cloudinary_params[ $key ], $value ) ) {
+			if ( array_key_exists( $key, $this->cloudinary_params ) && $this->valid_value( $this->cloudinary_params[ $key ], $value ) ) {
 				switch ( $key ) {
 					case 'progressive':
 						if ( true === $value ) {
-							$slug[] = $cloudinary_params[ $key ];
+							$slug[] = $this->cloudinary_params[ $key ];
 						} else {
-							$slug[] = $cloudinary_params[ $key ] . ':' . $value;
+							$slug[] = $this->cloudinary_params[ $key ] . ':' . $value;
 						}
 						break;
 					default:
-						$slug[] = $cloudinary_params[ $key ] . '_' . $value;
+						$slug[] = $this->cloudinary_params[ $key ] . '_' . $value;
 				}
 			}
 		}

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -152,7 +152,7 @@ class Core {
 		if ( ! empty( $args['file_name'] ) ) {
 			$url .= '/images';
 		}
-		
+
 		$extension = null;
 
 		if ( ! empty( $args['transform']['format'] ) && 'auto' !== $args['transform']['format'] ) {
@@ -195,9 +195,12 @@ class Core {
 		// Get our URLs the first time this function is called.
 		if ( empty( $this->_urls ) ) {
 			if ( ! empty( $this->_options['urls'] ) ) {
-				$this->_urls = array_map( function( $url ) {
-					return rtrim( $url, '/' );
-				}, array_map( 'trim', explode( "\n", $this->_options['urls'] ) ) );
+				$this->_urls = array_map(
+					function( $url ) {
+						return rtrim( $url, '/' );
+					},
+					array_map( 'trim', explode( "\n", $this->_options['urls'] ) )
+				);
 			}
 
 			$this->_urls        = apply_filters( 'cloudinary_urls', $this->_urls );

--- a/inc/class-frontend.php
+++ b/inc/class-frontend.php
@@ -130,9 +130,12 @@ class Frontend {
 						}
 					}
 
-					$dimensions = array_merge_recursive( $dimensions, array(
-						'crop' => cloudinary_default_crop( $hard_crop ),
-					) );
+					$dimensions = array_merge_recursive(
+						$dimensions,
+						array(
+							'crop' => cloudinary_default_crop( $hard_crop ),
+						)
+					);
 					$transform  = array(
 						'transform' => $dimensions,
 					);

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -37,7 +37,6 @@ if ( ! function_exists( 'cloudinary_update_content_images' ) ) {
 				$width  = preg_match( '/ width="([0-9]+)"/', $image, $match_width ) ? (int) $match_width[1] : 0;
 				$height = preg_match( '/ height="([0-9]+)"/', $image, $match_height ) ? (int) $match_height[1] : 0;
 				$class  = preg_match( '/ class="([^"]*)"/', $image, $match_class ) ? $match_class[1] : '';
-				
 
 				if ( ! empty( $class ) ) {
 					$size = preg_match( '/size-([a-zA-Z0-9-_]+)?/', $class, $match_size ) ? $match_size[1] : '';
@@ -153,48 +152,51 @@ if ( ! function_exists( 'cloudinary_default_crop' ) ) {
  * Get an image HTML tag
  *
  * @param integer $image_id Image ID or URL
- * @param array $options An array of image options. Any support cloudinary transformation can be passed:
- * 
- * [
- *   'transform' => [
- *      'width'  => 'Image width',
- *      'height' => 'Image height',
- *      'crop'   => 'fill',
- *      'size'   => 'post-thumbnail', // Instead of passing a width and/or height, you can pass a registered WP image size
+ * @param array   $options An array of image options. Any support cloudinary transformation can be passed:
+ *
+ *   [
+ *     'transform' => [
+ *        'width'  => 'Image width',
+ *        'height' => 'Image height',
+ *        'crop'   => 'fill',
+ *        'size'   => 'post-thumbnail', // Instead of passing a width and/or height, you can pass a registered WP image size
+ *     ]
+ *     'srcs' => [ // Corresponds to srcset
+ *         '500w' => [
+ *            'src' => 'URL or image ID',
+ *            'transform' => [
+ *              'width' => ....
+ *              'crop'  => 'fill',
+ *              ...
+ *              // All cloudinary arguments can be passed here
+ *            ]
+ *          ],
+ *     ]
+ *     'sizes' => [ // Corresponds "sizes" attribute for use with srcet
+ *        '(min-width: 1000px) 916px',
+ *        '(min-width: 1536px) 1030px',
+ *        '100vw',
+ *     ],
+ *     'atts'  => [ //Extra attributes to be passed to the image tag
+ *        'loading' => 'lazy',
+ *     ],
  *   ]
- *   'srcs' => [ // Corresponds to srcset
- *       '500w' => [
- *          'src' => 'URL or image ID',
- *          'transform' => [
- *            'width' => ....
- *            'crop'  => 'fill',
- *            ...
- *            // All cloudinary arguments can be passed here
- *          ]
- *        ],
- *   ]
- *   'sizes' => [ // Corresponds "sizes" attribute for use with srcet
- *      '(min-width: 1000px) 916px', 
- *      '(min-width: 1536px) 1030px', 
- *      '100vw',
- *   ],
- *   'atts'  => [ //Extra attributes to be passed to the image tag
- * 	    'loading' => 'lazy',
- *   ],
- * ]
  * @return void
  */
 function cloudinary_image( $image_id = 0, $options = array() ) {
 	// Default args.
-	$options = array_replace_recursive( array(
-		'transform' => [
-			'crop'   => 'fill',
-			'format' => 'auto',
-		],
-		'atts'      => [
-			'loading' => 'lazy',
-		],
-	), $options );
+	$options = array_replace_recursive(
+		array(
+			'transform' => [
+				'crop'   => 'fill',
+				'format' => 'auto',
+			],
+			'atts'      => [
+				'loading' => 'lazy',
+			],
+		),
+		$options
+	);
 
 	global $_wp_additional_image_sizes;
 
@@ -211,7 +213,7 @@ function cloudinary_image( $image_id = 0, $options = array() ) {
 	// Check for sizes.
 	if ( ! empty( $options['transform']['size'] ) ) {
 		$size = JB\Cloudinary\Frontend::get_instance()->get_image_size( $options['transform']['size'] );
-		
+
 		if ( ! empty( $size ) ) {
 			$options['transform']['width']  = $size['width'];
 			$options['transform']['height'] = $size['height'];
@@ -260,7 +262,7 @@ function cloudinary_image( $image_id = 0, $options = array() ) {
 	}
 
 	$atts['src'] = $url;
-	
+
 	if ( empty( $atts['alt'] ) && is_numeric( $image_id ) ) {
 		$alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
 
@@ -290,7 +292,7 @@ function cloudinary_image( $image_id = 0, $options = array() ) {
 
 			for ( $i = 400; $i < $options['transform']['width']; $i += 200 ) {
 				$src_options = [
-					'transform' => [ 
+					'transform' => [
 						'width'  => $i,
 						'format' => 'auto',
 					],

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -37,6 +37,7 @@ if ( ! function_exists( 'cloudinary_update_content_images' ) ) {
 				$width  = preg_match( '/ width="([0-9]+)"/', $image, $match_width ) ? (int) $match_width[1] : 0;
 				$height = preg_match( '/ height="([0-9]+)"/', $image, $match_height ) ? (int) $match_height[1] : 0;
 				$class  = preg_match( '/ class="([^"]*)"/', $image, $match_class ) ? $match_class[1] : '';
+				
 
 				if ( ! empty( $class ) ) {
 					$size = preg_match( '/size-([a-zA-Z0-9-_]+)?/', $class, $match_size ) ? $match_size[1] : '';
@@ -45,6 +46,12 @@ if ( ! function_exists( 'cloudinary_update_content_images' ) ) {
 				}
 
 				$updated_image = apply_filters( 'cloudinary_content_image', $image, $attachment_id, $src, $width, $height );
+
+				$cloudinary_args = array(
+					'transform' => array(
+						'format' => 'auto',
+					),
+				);
 
 				// Check if filter updated the image.
 				if ( $updated_image !== $image ) {
@@ -62,17 +69,15 @@ if ( ! function_exists( 'cloudinary_update_content_images' ) ) {
 							}
 						}
 
+						$cloudinary_args['transform']['crop']   = cloudinary_default_crop( $hard_crop );
+						$cloudinary_args['transform']['width']  = $width;
+						$cloudinary_args['transform']['height'] = $height;
+
 						// We have a width and height, let's use them to transform the image.
-						$updated_src = cloudinary_url( $attachment_id, array(
-							'transform' => array(
-								'width'  => $width,
-								'height' => $height,
-								'crop'   => cloudinary_default_crop( $hard_crop ),
-							),
-						) );
+						$updated_src = cloudinary_url( $attachment_id, $cloudinary_args );
 					} else {
 						// No width and height from the image, let's default to the full URL.
-						$updated_src = cloudinary_url( $src );
+						$updated_src = cloudinary_url( $src, $cloudinary_args );
 					}
 
 					if ( ! empty( $updated_src ) ) {
@@ -142,4 +147,182 @@ if ( ! function_exists( 'cloudinary_default_crop' ) ) {
 			return apply_filters( 'cloudinary_default_soft_crop', apply_filters( 'cloudinary_default_crop', $core->_default_soft_crop ) );
 		}
 	}
+}
+
+/**
+ * Get an image HTML tag
+ *
+ * @param integer $image_id Image ID or URL
+ * @param array $options An array of image options. Any support cloudinary transformation can be passed:
+ * 
+ * [
+ *   'transform' => [
+ *      'width'  => 'Image width',
+ *      'height' => 'Image height',
+ *      'crop'   => 'fill',
+ *      'size'   => 'post-thumbnail', // Instead of passing a width and/or height, you can pass a registered WP image size
+ *   ]
+ *   'srcs' => [ // Corresponds to srcset
+ *       '500w' => [
+ *          'src' => 'URL or image ID',
+ *          'transform' => [
+ *            'width' => ....
+ *            'crop'  => 'fill',
+ *            ...
+ *            // All cloudinary arguments can be passed here
+ *          ]
+ *        ],
+ *   ]
+ *   'sizes' => [ // Corresponds "sizes" attribute for use with srcet
+ *      '(min-width: 1000px) 916px', 
+ *      '(min-width: 1536px) 1030px', 
+ *      '100vw',
+ *   ],
+ *   'atts'  => [ //Extra attributes to be passed to the image tag
+ * 	    'loading' => 'lazy',
+ *   ],
+ * ]
+ * @return void
+ */
+function cloudinary_image( $image_id = 0, $options = array() ) {
+	// Default args.
+	$options = array_replace_recursive( array(
+		'transform' => [
+			'crop'   => 'fill',
+			'format' => 'auto',
+		],
+		'atts'      => [
+			'loading' => 'lazy',
+		],
+	), $options );
+
+	global $_wp_additional_image_sizes;
+
+	// Just in case width or height were set in the root of the array.
+
+	if ( ! empty( $options['width'] ) ) {
+		$options['transform']['width'] = $options['width'];
+	}
+
+	if ( ! empty( $options['height'] ) ) {
+		$options['transform']['height'] = $options['height'];
+	}
+
+	// Check for sizes.
+	if ( ! empty( $options['transform']['size'] ) ) {
+		$size = JB\Cloudinary\Frontend::get_instance()->get_image_size( $options['transform']['size'] );
+		
+		if ( ! empty( $size ) ) {
+			$options['transform']['width']  = $size['width'];
+			$options['transform']['height'] = $size['height'];
+
+			if ( isset( $size['crop'] ) ) {
+				$options['transform']['crop'] = $size['crop'];
+			}
+		}
+
+		unset( $options['transforms']['size'] );
+	}
+
+	// Return.
+	$cloudinary_args = array(
+		'transform' => $options['transform'],
+	);
+
+	if ( ! empty( $options['file_name'] ) ) {
+		$cloudinary_args['file_name'] = $options['file_name'];
+	}
+
+	$options['original_url'] = $image_id;
+
+	$url = cloudinary_url( $image_id, $cloudinary_args );
+
+	$atts = ! empty( $options['atts'] ) ? $options['atts'] : [];
+
+	$blocklist_atts = [
+		'src',
+		'width',
+		'height',
+	];
+
+	foreach ( $blocklist_atts as $key => $value ) {
+		if ( isset( $atts[ $key ] ) ) {
+			unset( $atts[ $key ] );
+		}
+	}
+
+	if ( ! empty( $options['transform']['width'] ) ) {
+		$atts['width'] = (int) $options['transform']['width'];
+	}
+
+	if ( ! empty( $options['transform']['height'] ) ) {
+		$atts['height'] = (int) $options['transform']['height'];
+	}
+
+	$atts['src'] = $url;
+	
+	if ( empty( $atts['alt'] ) && is_numeric( $image_id ) ) {
+		$alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+
+		if ( ! empty( $alt ) ) {
+			$atts['alt'] = $alt;
+		}
+	}
+
+	if ( ! empty( $options['srcs'] ) && ! empty( $options['sizes'] ) ) {
+		$srcs = [];
+
+		foreach ( $options['srcs'] as $key => $src_options ) {
+			if ( empty( $src_options['src'] ) ) {
+				$src_options['src'] = $url;
+			}
+
+			$srcs[] = cloudinary_url( $src_options['src'], $src_options ) . ' ' . $key;
+		}
+
+		$atts['srcset'] = implode( ', ', $srcs );
+		$atts['sizes']  = implode( ', ', $options['sizes'] );
+	} else {
+		if ( ! empty( $options['transform']['width'] ) && 600 <= $options['transform']['width'] ) {
+			$sizes = [
+				'100vw',
+			];
+
+			for ( $i = 400; $i < $options['transform']['width']; $i += 200 ) {
+				$src_options = [
+					'transform' => [ 
+						'width'  => $i,
+						'format' => 'auto',
+					],
+				];
+
+				$srcs[] = cloudinary_url( $options['original_url'], $src_options ) . ' ' . $i . 'w';
+			}
+
+			$srcs[] = $url . ' ' . $options['transform']['width'] . 'w';
+
+			$atts['srcset'] = implode( ', ', $srcs );
+			$atts['sizes']  = implode( ', ', $sizes );
+		}
+	}
+
+	// Start building the tag.
+	$img = '<img';
+
+	// Add attributes.
+	foreach ( $atts as $key => $value ) {
+		if ( true === $value ) {
+			$value = 'true';
+		} elseif ( false === $value ) {
+			$value = 'false';
+		}
+
+		$img .= ' ' . $key . '="' . $value . '"';
+	}
+
+	// Finish building the tag.
+	$img .= '>';
+
+	// All set, let's return it.
+	return $img;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,20 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards for Plugins">
-	<description>Generally-applicable sniffs for WordPress plugins</description>
+<ruleset name="10up PHPCS">
+  <description>10up PHPCS extended.</description>
 
-	<rule ref="WordPress-Core">
-	    <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
-	    <exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
-	    <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
-	</rule>
-
-	<!-- Check all PHP files in directory tree by default. -->
-	<arg name="extensions" value="php"/>
-	<file>.</file>
-
-	<!-- Show progress and sniff codes in all reports -->
-	<arg value="ps"/>
-
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
+  <rule ref="10up-Default">
+    <exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
+  </rule>
 </ruleset>


### PR DESCRIPTION
This PR does the following:
- Adds the `cloudinary_image` function for outputting a Cloudinary image via PHP. It supports arguments similar to `cloudinary_url`.
- Adds the `format` transformation and defaults to `auto` for transformations done to `post_content.
- Adds `.editorconfig`
- Sets up Composer.
- Switches to 10up PHPCS rules.
- Updates documentation.

Let me know your thoughts.